### PR TITLE
Fix description's new-lines

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: hexchat
 version: "2.12.4"
 summary: HexChat IRC Client
-description: |
+description: >
   HexChat is a graphical IRC client with a GTK+ GUI. Features include Python
   and Perl scripting support, a plugin API, multiple server/channel windows,
   spell checking, multiple authentication methods including SASL, and


### PR DESCRIPTION
https://snapcraft.io/hexchat is showing the description as encoded in YAML, but it seems that the description doesn't actually want new lines. This fixes the YAML to use `>` instead of `|` to turn the new lines into spaces. See http://yaml-multiline.info/ for further details